### PR TITLE
Variable rate process

### DIFF
--- a/uit_scripts/shotnoise/gen_shot_noise.py
+++ b/uit_scripts/shotnoise/gen_shot_noise.py
@@ -71,9 +71,173 @@ def sample_bounded_Pareto(alpha = 1., L = 1., H = 100., size=None, seed=None):
 
     return H*L*( (1-U)*H**alpha + U*L**alpha )**(-1./alpha)
 
+def create_rate(version, gamma, K, k_length=True, tw=False):
+    """Create a variable rate based on gamma using either of two methods.
+
+    Versions:
+        'ou' creates an Ornstein-Uhlenbeck process with length K or
+            int(1e5), based on a SDE implemented using the library 'sdepy'.
+            The processes is scaled to have a mean of gamma and returned as
+            rate or as 1 / rate.
+        'n-random' creates K or int(1e5) random floating pt. numbers drawn
+            from a Gamma distribution (can be changed manually), where the
+            scale is either gamma or 1 / gamma.
+
+    Args:
+        version (str): the version used to generate the rate array (see above)
+        gamma (float): intermittency parameter
+        K (int): number of arrivals
+        k_length (bool, optional): If True, the rate array has length K,
+                                   else, length int(1e5). Defaults to True.
+        tw (bool, optional): If True, return the waiting time (i.e. 1 / rate)
+                             instead of the rate process. Defaults to False.
+
+    Returns:
+        rate (np.ndarray): the rate process with shape (K,) or (int(1e5),)
+        t (np.ndarray): the time axis for the rate process (same shape)
+    """
+    import numpy as np
+    import sdepy
+
+    T = K / gamma
+    assert version in ['ou', 'n-random']
+    # Use an Ornstein-Uhlenbeck process as the rate
+    if version == 'ou':
+        # From Matthieu Garcin. Hurst exponents and delampertized fractional Brownian motions. 2018. hal-01919754
+        # https://hal.archives-ouvertes.fr/hal-01919754/document
+        # and https://sdepy.readthedocs.io/en/v1.1.1/intro.html#id2
+        # This uses a Wiener process as dW(t)
+        @sdepy.integrate
+        def rate_process(t, x, mu=2., k=.1, sigma=1.):
+            return {'dt': k * (mu - x), 'dw': sigma}
+        # k: speed of reversion = .1
+        # mu: long-term average position = 1.
+        # sigma: volatility parameter = 1.
+        size = K if k_length else int(1e5)
+        timeline = np.linspace(0., 1., size)
+        t = np.linspace(0., T, size)
+        rate = rate_process(x0=1.)(timeline)  # pylint: disable=E1102,E1123,E1120
+        rate = rate.reshape((-1,))
+        rate *= gamma / rate.mean()
+        rate = rate if not tw else 1 / rate
+    # Use n random numbers as the rate, drawn from a gamma distribution
+    elif version == 'n-random':
+        prob = np.random.default_rng()
+        size = K if k_length else int(1e5)
+        # Return rate as a waiting time if True, else as a varying gamma.
+        scale = 1 / gamma if tw else gamma
+        rate = prob.gamma(shape=1., scale=scale, size=size)
+        # rate = prob.exponential(scale=scale, size=size)
+        t = np.linspace(0, np.sum(rate), size)
+    if any(rate < 0):
+        print('Warning: Rate process includes negatives. Computing abs(rate).')
+        rate = abs(rate)
+    return rate, t
+
+def find_nearest(array, value):
+    """Find the indices of 'array' that are closest to the values in 'values'.
+
+    Shape of array: (n,); shape of values: (k,). n>=k.
+
+    Args:
+        array (list or np.ndarray): array that is searched
+        value (iterable): elements must be numerical and should
+                          reflect values in 'array'
+
+    Returns:
+        idx (list): the masking of 'array' that will return an array with
+                    length of 'values' and elements closest to the elements
+                    of 'values'.
+    """
+    import numpy as np
+
+    idx = []
+    array = np.asarray(array)
+    for i in value:
+        idx.append((np.abs(array - i)).argmin())
+    return idx
+
+def create_ampta(rate, gamma, K):
+    """Create arrival times (or waiting time scales) based on either
+    of three different versions. The function 'create_rate' is called
+    which generates the rate process that this function depend on.
+
+    Versions:
+        'int' uses a rate process with shape (int(1e5),) and finds the
+            cumulative sum of the process. Arrival times are given as
+            the indices where the cumulative sum has increased with
+            some constant amount, i.e., equal spacing along the y-axis
+            give the arrivals as time on the x-axis.
+        '2-rd-tw' stands for double random waiting times. K random
+            numbers are drawn from a Gamma distribution with scale
+            =1 / gamma and shape=1. The array of K floats are returned
+            and used as the scale parameters to create K waiting times,
+            that is, the K waiting times are drawn from similar
+            distributions but that has different scale parameter.
+        'tick' uses the python library tick and the class
+            SimuInhomogeneousPoisson to create arrival times from
+            a rate process of length int(1e5). The library finds
+            arrival times based on a varying rate (at each time step
+            of the rate process the rate give the probability of an
+            event / arrival) and the final number of arrivals will
+            vary, but stay close to K (K must therefore be reset).
+
+    Args:
+        rate (np.ndarray): the rate process [shape=(K or int(1e5),)]
+        gamma (float): intermittency parameter
+        K (int): number of arrivals
+
+    Returns:
+        ta (np.ndarray): arrival times (or waiting time scales), shape
+                         (K or int(1e5),).
+        K (int): if 'tick', the number of arrivals is reset and returned,
+                 else returns None.
+    """
+    import numpy as np
+    import tick.base as tb
+    import tick.hawkes as th
+    import tick.plot as tp
+
+    Vrate, version = rate
+    T = K / gamma
+    assert version in ['int', '2-rd-tw', 'tick']
+    if version == 'int':
+        rate, t = create_rate(Vrate, gamma, K, k_length=False)
+        int_thresholds = np.linspace(0, np.sum(rate), K)
+        c_sum = np.cumsum(rate)
+        ta = find_nearest(c_sum, int_thresholds)
+        ta = t[ta]
+        # Normalize arrival times to within T_max
+        ta = ta * T / np.ceil(np.max(ta))
+        # amp, _, _ = gsn.amp_ta(gamma, K)
+        return ta, K, T
+    if version == '2-rd-tw':
+        k_length = True
+        tw, _ = create_rate(Vrate, gamma, K, k_length=k_length, tw=True)
+        if not k_length:
+            idx = np.round(np.linspace(
+                0, len(tw) - 1, K)).astype(int)
+            tw = tw[idx]
+        # amp, ta, self.T = gsn.amp_ta(
+        #     1 / tw, self.K, TWdist='gam', Adist=self.amp, TWkappa=.1)
+        return tw, K, T
+    if version == 'tick':
+        rate, t = create_rate(Vrate, gamma, K, k_length=False)
+        tf = tb.TimeFunction((t, rate))
+        ipp = th.SimuInhomogeneousPoisson(
+            [tf], end_time=T, verbose=False)
+        ipp.track_intensity()  # Accepts float > 0 to set time step of reproduced rate process
+        ipp.threshold_negative_intensity()
+        ipp.simulate()
+        ta = ipp.timestamps[0]
+        K = len(ta)
+        # amp, _, _ = gsn.amp_ta(self.gamma, self.K)
+    return ta, K, T
+
 def amp_ta(
-        gamma, K, Kdist=False, mA=1., kappa=0.5, TWkappa = 0.,
-        TWdist='exp', Adist='exp', seedTW=None, seedA=None):
+        gamma, K, Kdist=False, mA=1., kappa=0.5, TWkappa=0.,
+        TWdist='exp', Adist='exp', rate=('n-random', 'const'),
+        seedTW=None, seedA=None):
     """
     Use:
         amp_ta(
@@ -93,6 +257,12 @@ def amp_ta(
         TWkappa: asymmetry parameter for TWdist. ........... float
         TWdist: Waiting time distribution (see below) ...... int in range(4)
         Adist: Amplitude distribution (see below) .......... int in range(5)
+        rate: The first position give which method to use
+              when generating the variable rate process
+              ('n-random' or 'ou'), and the second position
+              give the method to use to generate the
+              waiting times based on the given variable
+              rate ('int', '2-rd-tw', 'tick'). ............. tuple of str
         seedTW/A: Specify a random seed for TWdist/Adist ... int
     Options for distributions are (where m denotes either mA or tw=1/gamma):
         Note: Using a distribution which gives negative values for the
@@ -136,6 +306,7 @@ def amp_ta(
     distlist = ['exp','deg','ray','unif','unifc','gam','alap', 'pareto']
     assert(TWdist in distlist[:-2]), 'Invalid TWdist'
     assert(Adist in distlist), 'Invalid Adist'
+    assert rate[0] in ['n-random', 'ou'] and rate[1] in ('const', 'int', '2-rd-tw', 'tick'), 'Invalid rate tuple'
 
     prngTW = np.random.RandomState(seed=seedTW)
     prngA = np.random.RandomState(seed=seedA)
@@ -144,22 +315,31 @@ def amp_ta(
         K = np.random.poisson(lam=K)
 
     # Geneate ta, Tend
-    tw = 1./gamma
-    if TWdist == 'exp':
-        TW = prngTW.exponential(scale=tw, size=K)
-    elif TWdist == 'deg':
-        TW = tw*np.ones(K)
-    elif TWdist == 'ray':
-        TW = prngTW.rayleigh(scale=np.sqrt(2./np.pi)*tw, size=K)
-    elif TWdist == 'unif':
-        assert(TWkappa>=0.), 'TWkappa>=0 for TWdist uniform'
-        TW = prngTW.uniform(low=TWkappa, high=TWkappa+2*tw, size=K)
-    elif TWdist == 'gam':
-        TW = prngTW.gamma(TWkappa, scale=tw/TWkappa, size=K)
+    if rate[1] in ['const', '2-rd-tw']:
+        # Normal, constant waiting time (float)
+        if rate[1] == 'const':
+            tw = 1./gamma
+        # K random waiting times (np.ndarray)
+        elif rate[1] == '2-rd-tw':
+            tw, _, _ = create_ampta(rate, gamma, K)
+        # Generate based on either constant float or array with dim. (K,)
+        if TWdist == 'exp':
+            TW = prngTW.exponential(scale=tw, size=K)
+        elif TWdist == 'deg':
+            TW = tw*np.ones(K)
+        elif TWdist == 'ray':
+            TW = prngTW.rayleigh(scale=np.sqrt(2./np.pi)*tw, size=K)
+        elif TWdist == 'unif':
+            assert(TWkappa>=0.), 'TWkappa>=0 for TWdist uniform'
+            TW = prngTW.uniform(low=TWkappa, high=TWkappa+2*tw, size=K)
+        elif TWdist == 'gam':
+            TW = prngTW.gamma(TWkappa, scale=tw/TWkappa, size=K)
 
-    TW = np.insert(TW, 0, 0.)
-    ta = np.cumsum(TW[:-1])
-    Tend = ta[-1] + TW[-1]
+        TW = np.insert(TW, 0, 0.)
+        ta = np.cumsum(TW[:-1])
+        Tend = ta[-1] + TW[-1]
+    elif rate[1] in ['int', 'tick']:
+        ta, K, Tend = create_ampta(rate, gamma, K)
 
     # Generate amplitudes
     if Adist == 'exp':
@@ -371,8 +551,8 @@ def gen_noise(
 
 def make_signal(
         gamma, K, dt, Kdist=False, mA=1., kappa=0.5, TWkappa=0, ampta=False,
-        TWdist='exp', Adist='exp', seedTW=None, seedA=None, convolve=True,
-        dynamic=False, additive=False, eps=0.1, noise_seed=None,
+        TWdist='exp', Adist='exp', rate=('n-random', 'const'), seedTW=None, seedA=None,
+        convolve=True, dynamic=False, additive=False, eps=0.1, noise_seed=None,
         kernsize=2**11, kerntype=0, lam=0.5, dkern=False, tol=1e-5):
     """
     Use:
@@ -396,7 +576,7 @@ def make_signal(
     import numpy as np
     A, ta, Tend = amp_ta(
             gamma, K, Kdist=Kdist, mA=mA, kappa=kappa, TWkappa = TWkappa,
-            TWdist=TWdist, Adist=Adist, seedTW=seedTW, seedA=seedA)
+            TWdist=TWdist, Adist=Adist, rate=rate, seedTW=seedTW, seedA=seedA)
     if convolve:
         T, S = signal_convolve(
                 A, ta, Tend, dt,

--- a/uit_scripts/shotnoise/gen_shot_noise.py
+++ b/uit_scripts/shotnoise/gen_shot_noise.py
@@ -157,7 +157,7 @@ def find_nearest(array, value):
         idx.append((np.abs(array - i)).argmin())
     return idx
 
-def create_ampta(rate, gamma, K):
+def create_ta(rate, gamma, K):
     """Create arrival times (or waiting time scales) based on either
     of three different versions. The function 'create_rate' is called
     which generates the rate process that this function depend on.
@@ -321,7 +321,7 @@ def amp_ta(
             tw = 1./gamma
         # K random waiting times (np.ndarray)
         elif rate[1] == '2-rd-tw':
-            tw, _, _ = create_ampta(rate, gamma, K)
+            tw, _, _ = create_ta(rate, gamma, K)
         # Generate based on either constant float or array with dim. (K,)
         if TWdist == 'exp':
             TW = prngTW.exponential(scale=tw, size=K)
@@ -339,7 +339,7 @@ def amp_ta(
         ta = np.cumsum(TW[:-1])
         Tend = ta[-1] + TW[-1]
     elif rate[1] in ['int', 'tick']:
-        ta, K, Tend = create_ampta(rate, gamma, K)
+        ta, K, Tend = create_ta(rate, gamma, K)
 
     # Generate amplitudes
     if Adist == 'exp':


### PR DESCRIPTION
Adds functions `create_rate` and `create_ta` used in `amp_ta`. The functions implement methods for calculating arrival times from a variable rate.

Extra optional (keyword) argument `rate` added to `amp_ta` and `make_signal`, where `rate` is a tuple of str describing how to generate the rate process and the waiting times based on the rate process.

Depends on:
-   numpy==1.18.2
-   sdepy==1.1.1
-   tick==0.7.0.1